### PR TITLE
Fix Website URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Loot
 
-Community-operated [website](https://lootrng.com) for the Loot project.
+Community-operated [website](https://www.lootproject.com/) for the Loot project.
 
 ## Contribute
 


### PR DESCRIPTION
Fixes the README URL to point to https://www.lootproject.com/