### PR TITLE
fix: replace direct discord with gated access link

### DIFF
--- a/utils/lists.ts
+++ b/utils/lists.ts
@@ -81,9 +81,9 @@ export const guildsList: Record<string, string>[] = [
     url: "https://tinyurl.com/ancientadventurers",
   },
   {
-    name: "Katana Gang",
+    name: "Katana Garden",
     description: "For owners of Katanas",
-    url: "https://tinyurl.com/j4akkrmd",
+    url: "https://katana.garden",
   },
 ];
 


### PR DESCRIPTION
Katana Gang has deployed a gated access bot to add katana roles at katana.garden. see discord > announcements for validation