### PR TITLE
feat: add doggos for dog owners to resources

### DIFF
--- a/utils/lists.ts
+++ b/utils/lists.ts
@@ -294,7 +294,7 @@ export const derivativesList: Record<string, string>[] = [
   },
   {
     name: "Doggos (for $DOG Owners)",
-    description: "Doggos are 6969 playful lootiverse companions, adopt-able by anyone who owns a fraction of The Doge NFT ($DOG).",
-    url: "https://doge.pleasr.org"
+    description: "Playful lootiverse companions adopt-able by owners of The Doge NFT ($DOG).",
+    url: "https://etherscan.io/address/0x76e3dea18e33e61de15a7d17d9ea23dc6118e10f#writeContract"
   },
 ];

--- a/utils/lists.ts
+++ b/utils/lists.ts
@@ -292,4 +292,9 @@ export const derivativesList: Record<string, string>[] = [
     description: "Journey maps and location names for your Loot Adventures.",
     url: "https://mapsproject.xyz"
   },
+  {
+    name: "Doggos (for $DOG Owners)",
+    description: "Doggos are 6969 playful lootiverse companions, adopt-able by anyone who owns a fraction of The Doge NFT ($DOG).",
+    url: "https://doge.pleasr.org"
+  },
 ];


### PR DESCRIPTION
wasn't sure what the best link to include was, since an etherscan would be too obscure, and the discord might not be what people expect, so i choose the doge homepage, which explains the doge and has a link to the discord. lmk if there's a better option