### PR TITLE
add Loot Bibliotheca

### DIFF
--- a/utils/lists.ts
+++ b/utils/lists.ts
@@ -67,7 +67,7 @@ export const resourceList: Record<string, string>[] = [
   },
   {
     name: "Loot Bibliotheca (for Adventurers)",
-    description: "Graphing community projects into one dashboard for adventurers to explore.",
+    description: "Graphing community projects for adventurers to explore.",
     url: "https://loot-bibliotheca-client.vercel.app/",
   },
 ];

--- a/utils/lists.ts
+++ b/utils/lists.ts
@@ -67,7 +67,7 @@ export const resourceList: Record<string, string>[] = [
   },
   {
     name: "Loot Bibliotheca (for Adventurers)",
-    description: "Graphing community projects for adventurers to explore.",
+    description: "Graphing community projects for adventurers to explore",
     url: "https://loot-bibliotheca-client.vercel.app/",
   },
 ];

--- a/utils/lists.ts
+++ b/utils/lists.ts
@@ -65,6 +65,11 @@ export const resourceList: Record<string, string>[] = [
     description: "Utility contract to easily interact with Loot properties",
     url: "https://etherscan.io/address/0x3eb43b1545a360d1D065CB7539339363dFD445F3#code",
   },
+  {
+    name: "Loot Bibliotheca (for Adventurers)",
+    description: "Graphing community projects into one dashboard for adventurers to explore.",
+    url: "https://loot-bibliotheca-client.vercel.app/",
+  },
 ];
 
 // Loot guilds


### PR DESCRIPTION
**Added Loot Bibliotheca (for Adventurers) into the resource list.**

Loot Bibliotheca graphs approved community projects together so adventurers can see their progress in the Loot verse.

https://loot-bibliotheca-client.vercel.app/