### PR TITLE
Add Resource: Encyclopedia for Adventurers

### DIFF
--- a/utils/lists.ts
+++ b/utils/lists.ts
@@ -85,6 +85,11 @@ export const resourceList: Record<string, string>[] = [
     description: "Graphing community projects for adventurers to explore",
     url: "https://loot-bibliotheca-client.vercel.app/",
   },
+  {
+    name: "Encyclopedia (for Adventurers)",
+    description: "Visual Guide to Loot Derivatives",
+    url: "https://accesspegasus.notion.site/An-Encyclopedia-for-Adventurers-6f0c0e04fe154fed9a2ad2482bd41cc3",
+  },
 ];
 
 // Loot guilds


### PR DESCRIPTION
## Encyclopedia for Adventurers

This is meant to be a visual of the loot ecosystem so people can know what the NFTs they will get look like before they mint them. 

Website: https://accesspegasus.notion.site/An-Encyclopedia-for-Adventurers-6f0c0e04fe154fed9a2ad2482bd41cc3 

