### PR TITLE
require trailing comma for multiline objects and array

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,9 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "comma-dangle": ["error", {
+      "arrays": "always-multiline",
+      "objects": "always-multiline"
+    }]
+  }
 }

--- a/pages/resources.tsx
+++ b/pages/resources.tsx
@@ -16,7 +16,7 @@ const resources = [
   {
     title: "Communities",
     description: "Spaces run by the community for Loot enthusiasts to share news and build together:",
-    list: communityList
+    list: communityList,
   },
   {
     title: "Developer Tooling",

--- a/utils/lists.ts
+++ b/utils/lists.ts
@@ -13,8 +13,8 @@ export const communityList: Record<string, string>[] = [
   {
     name: "Loot Builders Discord",
     description: "Focused on developers, artists, and writers with minimal derivative, token, and market chat",
-    url: "https://discord.gg/Btefs83ART"
-  }
+    url: "https://discord.gg/Btefs83ART",
+  },
 ];
 
 // Loot resources
@@ -265,7 +265,7 @@ export const derivativesList: Record<string, string>[] = [
   {
     name: "Emoji Loot",
     description: "Emojis for your lifestyle.",
-    url: "https://emloot.xyz"
+    url: "https://emloot.xyz",
   },
   {
     name: "Encounters",
@@ -320,7 +320,7 @@ export const derivativesList: Record<string, string>[] = [
   {
     name: "Loot Companions",
     description: "Companions for your Loot Adventures.",
-    url: "https://companionsproject.io"
+    url: "https://companionsproject.io",
   },
   {
     name: "Loot Conditions",
@@ -330,7 +330,7 @@ export const derivativesList: Record<string, string>[] = [
   {
     name: "Loot for Ape",
     description: "One of the experimental projects for the Ape world.",
-    url: "https://www.lootloot.io"
+    url: "https://www.lootloot.io",
   },
   {
     name: "Loot (for Cyberpunks)",
@@ -365,17 +365,17 @@ export const derivativesList: Record<string, string>[] = [
   {
     name: "Loot Of Ether",
     description: "Random visual gear generated with Loot items list.",
-    url: "https://twitter.com/lootofether"
+    url: "https://twitter.com/lootofether",
   },
   {
     name: "LootRock",
     description: "LootRock is the perfect collision of Loot and EtherRock.",
-    url: "https://opensea.io/collection/ethlootrock"
+    url: "https://opensea.io/collection/ethlootrock",
   },
   {
     name: "LootRock (for Adventurers)",
     description: "Inspired from EtherRock. Only 100 in existence.",
-    url: "https://opensea.io/collection/lootrock-for-adventurers"
+    url: "https://opensea.io/collection/lootrock-for-adventurers",
   },
   {
     name: "Loot Personalities v0.1",
@@ -385,7 +385,7 @@ export const derivativesList: Record<string, string>[] = [
   {
     name: "Maps",
     description: "Journey maps and location names for your Loot Adventures.",
-    url: "https://mapsproject.xyz"
+    url: "https://mapsproject.xyz",
   },
   {
     name: "Monsters",
@@ -425,7 +425,7 @@ export const derivativesList: Record<string, string>[] = [
   {
     name: "Planets with Loot",
     description: "Randomized Planets generated and stored on-chain",
-    url: "https://lootplanets.net/"
+    url: "https://lootplanets.net/",
   },
   {
     name: "Playlists",
@@ -455,7 +455,7 @@ export const derivativesList: Record<string, string>[] = [
   {
     name: "Runes",
     description: "Mysterious runes randomly generated and carved on chain. Gift from ancient world!",
-    url: "https://runesmystery.github.io/"
+    url: "https://runesmystery.github.io/",
   },
  {
     name: "sexy Loot - sLoots",
@@ -465,12 +465,12 @@ export const derivativesList: Record<string, string>[] = [
   {
     name: "Spells for Looters",
     description: "Spells and Spellbooks for Loot Adventurers.",
-    url: "https://opensea.io/collection/spells-for-looters"
+    url: "https://opensea.io/collection/spells-for-looters",
   },
   {
     name: "Spells (For Wizards and other Adventurers)",
     description: "Spells (For Wizards and other Adventurers)",
-    url: "https://etherscan.io/address/0x38e942948cea825992f105e0ec4a2ee9138afae4"
+    url: "https://etherscan.io/address/0x38e942948cea825992f105e0ec4a2ee9138afae4",
   },
   {
     name: "Summons",


### PR DESCRIPTION
When maintaining this repo, I found at least half of the PR miss the trailing comma for resources/derivatives they add. This PR hopefully can reduce our maintenance workload and let the PR authors fix this styling issue by themselves.

This style requirement is preferable because it is better for styling consistency, also adding a comma makes git code change easier to detect (see https://eslint.org/docs/rules/comma-dangle).

This PR also fix the previously missing commas.

@domhofmann @Anish-Agnihotri @ravindranrahul PTAL? Thanks!