### PR TITLE
One-lined another link

### DIFF
--- a/utils/lists.ts
+++ b/utils/lists.ts
@@ -219,7 +219,7 @@ export const derivativesList: Record<string, string>[] = [
   },
   {
     name: "Adventure Gems (for loot)",
-    description: "Rare and powerful on-chain gems 💎 for loot that give special powers",
+    description: "Rare and powerful on-chain gems 💎 that give special powers",
     url: "https://etherscan.io/address/0xebb3e4c387951059f89963a7c4539ee724a9de65#writeContract",
   },
   {
@@ -269,7 +269,7 @@ export const derivativesList: Record<string, string>[] = [
   },
   {
     name: "Doggos (for $DOG Owners)",
-    description: "Playful lootiverse companions adopt-able by owners of The Doge NFT ($DOG).",
+    description: "Companions adoptable by owners of The Doge NFT ($DOG)",
     url: "https://etherscan.io/address/0x76e3dea18e33e61de15a7d17d9ea23dc6118e10f#writeContract",
   },
   {


### PR DESCRIPTION
Realised that the adventuregems link still didn't one-line. There's also another link that didn't one-line so I fixed that one as well for cleanliness.