### PR TITLE
Add marz.farm

### DIFF
--- a/utils/lists.ts
+++ b/utils/lists.ts
@@ -403,6 +403,11 @@ export const derivativesList: Record<string, string>[] = [
     url: "https://mapsproject.xyz",
   },
   {
+    name: "Marz",
+    description: "MARZ PLOTS are a minimalist spatial framework for the Loot universe",
+    url: "https://marz.farm",
+  },
+  {
     name: "Monsters",
     description: "Slay unique Monsters with your Loot",
     url: "https://monstersforadventurers.com",


### PR DESCRIPTION
This commit adds the marz.farm derivative to the derivatives list

## Marz

Etherscan link: https://etherscan.io/address/0xd0ba8b19b0f5e25c11ed233302e75794c9d3142b

Website: https://marz.farm/

Twitter: https://twitter.com/marzplots

Discord: https://discord.gg/GDytXJpg
