### PR TITLE
Add Tideweigh Quests with Loot to resources

### DIFF
--- a/utils/lists.ts
+++ b/utils/lists.ts
@@ -537,6 +537,11 @@ export const derivativesList: Record<string, string>[] = [
     url: "https://etherscan.io/address/0x4de9d18Fd8390c12465bA3C6cc8032992fD7655d",
   },
   {
+    name: "Quests with Loot",
+    description: "Randomized, on-chain solvable Quests for owners of Loot. By Tideweigh.",
+    url: "https://opensea.io/collection/quests-with-loot",
+  },
+  {
     name: "Realms",
     description: "Realm Wonders forked from @UnchartedAtlas",
     url: "https://etherscan.io/address/0x7afe30cb3e53dba6801aa0ea647a0ecea7cbe18d#writeContract",


### PR DESCRIPTION
## Tideweigh Quests with Loot (for Adventurers)

Etherscan link: https://etherscan.io/address/0x012a0a0e5503f6915dcf186a88ce401492766b43#code 

Website: https://www.tideweigh.art

Twitter: https://twitter.com/tideweigh

Discord: no <!-- Discord user tideweigh#9155, but currently no Discord channel dedicated to these Quests -->
