### PR TITLE
added state to hold the 3 random bags.

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,6 @@
 // Imports
 import Link from "next/link"; // Local routing
+import { useState,useEffect } from "react"; // Needed hooks
 import Layout from "@components/Layout"; // Layout wrapper
 import { defaultBags } from "@utils/constants"; // Bags to render
 import styles from "@styles/pages/Home.module.scss"; // Styles
@@ -7,7 +8,19 @@ import styles from "@styles/pages/Home.module.scss"; // Styles
 // Types
 import type { ReactElement } from "react";
 
+//Interface to hold resulting array type of getRandomThreeBags function
+interface IRandombagsArray {
+    id: number;
+    attributes: string[];
+}
+
 export default function Home(): ReactElement {
+  const [randomBags,setRandomBags] = useState<IRandombagsArray[]>([]);
+
+  useEffect(()=>{
+    //setting three random bags from the sample loots list
+    setRandomBags(getRandomThreeBags());
+  },[])
   // Quicklinks to render
   const quicklinks: Record<string, string>[] = [
     { name: "OpenSea", url: "https://opensea.io/collection/lootproject" },
@@ -70,7 +83,7 @@ export default function Home(): ReactElement {
         {/* Rendering sample loot bags */}
         <div className={styles.home__feature}>
           <span>Example Bags:</span>
-          {getRandomThreeBags().map(({ id, attributes }, i) => (
+          {randomBags.map(({ id, attributes }, i) => (
             // For each loot bag, render item and link to OpenSea
             <a
               href={`https://opensea.io/assets/0xff9c1b15b16263c61d017ee9f65c50e4ae0113d7/${id}`}


### PR DESCRIPTION
As it is stated within the following issues, the presented sample loots and their redirecting OpenSea links' content are different and it leads to confusion.

https://github.com/lootproject/website/issues/126
https://github.com/lootproject/website/issues/120

There is a warning as in the following screenshot saying that "Warning: Text content did not match. Server: "6969" Client: "420"", so it seems that at least two times random numbers are generated before and after hydration, so inder order to keep the one generated in the client side I create a component state and generated random loot samples when component is mounting.
![image](https://user-images.githubusercontent.com/12461397/134925452-03b1cc8c-2767-402f-9834-20562271c13d.png)
