### PR TITLE
feat: add Quests for Loot to resources page

### DIFF
--- a/utils/lists.ts
+++ b/utils/lists.ts
@@ -553,7 +553,7 @@ export const derivativesList: Record<string, string>[] = [
   },
   {
     name: "Quests for Loot",
-    description: "Loot Adventurers, we need to slay Gary the Dragon! On-chain MUD to slay a world monster.",
+    description: "Loot Adventurers, we need to slay Gary the Dragon!",
     url: "https://questsforloot.com/",
   },
   {


### PR DESCRIPTION
Quests for Loot are battle records stored on-chain for a MUD to slay Gary the Dragon. He's ravaging a village, and Loot Adventurers must work together to defeat him and reap the rewards!

## Quests for Loot

Etherscan link: https://etherscan.io/address/0xF7EaD6bAe71DCB0B93dB5b33BF5B68dEf2039d9E

Website: https://questsforloot.com

Twitter: https://twitter.com/QuestsForLoot

Discord: https://discord.gg/KGvrA3KF
