### PR TITLE
Change url for owners of Ancient Loot

### DIFF
--- a/utils/lists.ts
+++ b/utils/lists.ts
@@ -101,7 +101,7 @@ export const guildsList: Record<string, string>[] = [
   {
     name: "The Ancients",
     description: "For owners of Ancient Loot",
-    url: "https://ancients.vercel.app/",
+    url: "https://ancients.app/",
   },
   {
     name: "CastleDAO",


### PR DESCRIPTION
<!-- 
Please use this pull request template when adding a new resource to the website. 
You do not have to fill out all the fields, but please attempt to complete as many as possible.

Please ensure:
1. Your contracts are verified
2. If adding a resource, the name and description must fit on one line

Thank you!
-->


## Project Name

The Ancients guild is moving away from vercel. We would like to change our URL to a domain we own. This changes the URL from `https://ancients.vercel.app/` to `https://ancients.app/`. Thank you.

Website: https://ancients.app/
